### PR TITLE
Fix some more julia 0.4 deprecations

### DIFF
--- a/src/Patchwork.jl
+++ b/src/Patchwork.jl
@@ -30,7 +30,7 @@ export Node,
        tohtml,
        writemime
 
-typealias MaybeKey Union(Nothing, Symbol)
+typealias MaybeKey @compat Union{(@compat Void), Symbol}
 
 # A Patchwork node
 abstract Node
@@ -41,8 +41,8 @@ end
 text(xs...) =
     Text(string(xs...))
 
-convert(::Type{Node}, s::String) = text(s)
-promote_rule(::Type{Node}, ::Type{String}) = Node
+convert(::Type{Node}, s::AbstractString) = text(s)
+promote_rule(::Type{Node}, ::Type{AbstractString}) = Node
 
 # Abstract out the word "Persistent"
 typealias NodeVector   PersistentVector{Node}
@@ -59,7 +59,7 @@ convert(::Type{NodeVector}, x::Node) =
 convert(::Type{NodeVector}, x::NodeVector) =
     x
 
-convert(::Type{NodeVector}, x::String) =
+convert(::Type{NodeVector}, x::AbstractString) =
     NodeVector([text(x)])
 
 convert(::Type{Props}, x::AbstractArray) = Props(x)

--- a/src/diff.jl
+++ b/src/diff.jl
@@ -105,8 +105,8 @@ function diff!{ns, tag}(a::Elem{ns, tag}, b::Elem{ns, tag}, index, patches)
 end
 
 are_equal(a::AbstractArray, b::AbstractArray) = a === b || a == b
-are_equal(a::String, b::Symbol) = a == string(b)
-are_equal(a::Symbol, b::String) = string(a) == b
+are_equal(a::AbstractString, b::Symbol) = a == string(b)
+are_equal(a::Symbol, b::AbstractString) = string(a) == b
 are_equal(a, b) = a == b
 
 function diff(a::Associative, b::Associative)

--- a/src/jsonfmt.jl
+++ b/src/jsonfmt.jl
@@ -14,7 +14,7 @@ function jsonfmt{ns, tag}(x::Elem{ns, tag})
     end
     dict
 end
-jsonfmt(::Nothing) = nothing
+jsonfmt(::(@compat Void)) = nothing
 
 # values from vtree/vpatch.js
 const VPATCH_NONE = 0

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -37,7 +37,7 @@ function make_tag(str)
 end
 
 # Given a string, returns a vector of elements
-function parse_elems(str::String, ns=:xhtml)
+function parse_elems(str::AbstractString, ns=:xhtml)
 
     node_stack = Node[Elem(:wrapper, :dummy)] # hack again
 

--- a/src/writers.jl
+++ b/src/writers.jl
@@ -16,7 +16,7 @@ end
 
 pwid() = replace(string(gensym("pwid")), "#", "")
 
-writemime(io::IO, ::MIME"application/json", x::Union(Node, Patch)) =
+writemime(io::IO, ::MIME"application/json", x::(@compat Union{Node, Patch})) =
     write(io, json(jsonfmt(x)))
 
 function writemime(io::IO, ::MIME"text/html", x::Node)


### PR DESCRIPTION
As a side note, with 0.4 being released, it might be a good time to think about support 0.4+ and getting rid of all of those `@compat` as well.
